### PR TITLE
Feature: Use file mtime for change detection

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,0 +1,59 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python testing
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  tests:
+    if: github.event.pull_request.draft == false
+    permissions: write-all
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.10"]
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Install Poetry
+      run: |
+        pipx install poetry==1.1.5
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: poetry
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Test with pytest
+      run: |
+        poetry run pytest
+
+    - name: Post Coverage Report
+      uses: orgoro/coverage@v3.1
+      with:
+        coverageFile: coverage.xml
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.6.8
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args:
+          - --fix
+          - --config
+          - pyproject.toml
+          - --select
+          - I,F401
+      # Run the formatter.
+      - id: ruff-format
+        args:
+          - --config
+          - pyproject.toml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args:
+         - -w
+  - repo: https://codeberg.org/frnmst/md-toc
+    rev: '9.0.0'
+    hooks:
+      - id: md-toc
+        args: ['-p', 'github', '-l6']
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.42.0
+    hooks:
+      - id: markdownlint
+        args:
+          - -c
+          - pyproject.toml
+          - --configPointer
+          - /tool/markdownlint
+          - --fix
+  - repo: https://github.com/netromdk/vermin
+    rev: v1.6.0
+    hooks:
+      - id: vermin
+        # specify your target version here, OR in a Vermin config file as usual:
+        args: ['-t=3.5-', '--violations']

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ attempting to load the config file. This way if there are any errors during the 
 they will be reported somewhere. You can customize the defaults using the following settings passed
 to the constructor.
 
-* default_level: int - A Python logging logging level, such as, DEBUG, INFO, WARNIGN, or ERROR
+* default_level: int - A Python logging logging level, such as, DEBUG, INFO, WARNING, or ERROR
 * default_format: str - A Python logging format string
 * default_handler: logging.Handler - A Python logging Handler type, such as, StreamHandler, FileHandler, etc, etc
 
@@ -30,9 +30,6 @@ This project uses [Poetry](https://python-poetry.org/) as its project manager.
 The goal of this library is to have no external runtime dependencies.
 However, for development, the following are used:
 
-* Black - For Formatting the code base
-* iSort - For sorting imports
-* autoflake - For removing unused imports and variables
-* poetry-bumpversion - For keeping the project and internal `__version__` value in sync
-
-If you make a PR, you must run the `format.sh` script or your PR will be rejected.
+* [pytest](https://pytest.org/) - For running tests
+* [pre-commit](https://pre-commit.com) - Pre-commit hooks to check formatting and lots of other things
+  * PR will automatically run these check and fail if they don't pass

--- a/log_config_watcher/log_config_watcher.py
+++ b/log_config_watcher/log_config_watcher.py
@@ -1,21 +1,23 @@
-import logging
-import logging.config
 from itertools import count
 from json import JSONDecodeError, loads
+import logging
+import logging.config
+from pathlib import Path
 from threading import Thread
 from time import sleep
 
 
 class LogConfigWatcher(Thread):
-    __COUNTER = count().__next__
+    __COUNTER = count(1).__next__
 
     def __init__(
         self,
         config_file,
         interval=30,
-        default_format: str="%(asctime)s | %(threadName)-15.15s | %(levelname)-5.5s | %(message)s",
-        default_level: int=logging.DEBUG,
-        default_handler: logging.Handler=logging.StreamHandler(),
+        default_format="%(asctime)s | %(threadName)-15.15s | %(levelname)-5.5s | %(message)s",
+        default_level=logging.DEBUG,
+        default_handler=logging.StreamHandler(),
+        warn_only_once=False,
     ):
         """A Runnable thread that will monitor your logging configuration file for changes and apply them.
 
@@ -27,6 +29,7 @@ class LogConfigWatcher(Thread):
             default_format {str} -- The logging format to use before a configuration file is loaded or if it fails to load (default: {"%(asctime)s | %(threadName)-15.15s | %(levelname)-5.5s | %(message)s"})
             default_level {_type_} -- The logging level to use before a configuration file is loaded or if it fails to load (default: {logging.DEBUG})
             default_handler {_type_} -- The logging handler to use before a configuration file is loaded or if it fails to load (default: {logging.StreamHandler()})
+            warn_only_once {bool} -- If true, only warn once if the configuration file is missing (default: {False})
 
         Example:
         ```
@@ -34,15 +37,21 @@ class LogConfigWatcher(Thread):
         log_wathcer.start()
         ```
         """
-        super().__init__(name=f"LogWatcher-{self.__COUNTER() + 1}", daemon=True)
+        super().__init__(name="LogWatcher-{}".format(self.__COUNTER()), daemon=True)
 
         self.log = logging.getLogger(__name__)
-        self.config_file = config_file
+        self.config_file = Path(config_file)
         self.interval = interval
+        self.warn_only_once = warn_only_once
 
         self._running = True
         self._previous_config = ""
-        self._missing_count = -1
+        self._missing_count = -1  # we start at -1 because we want the first miss to log but then only ever 4th time
+        self._last_file_size = 0
+        self._last_mtime = 0
+        self._last_ctime = 0
+        self._last_inode = 0
+        self._warned = False
 
         # Ensure at least a basic logger is ready
         logging.basicConfig(level=default_level, format=default_format, handlers=[default_handler])
@@ -51,7 +60,8 @@ class LogConfigWatcher(Thread):
 
     def run(self):
         while self._running:
-            self._update()
+            if self._check_modification_time():
+                self._update()
             sleep(self.interval)
 
     def stop(self):
@@ -63,9 +73,33 @@ class LogConfigWatcher(Thread):
         if new_config:
             self._apply_config(new_config)
 
+    def _check_modification_time(self):
+        try:
+            file_stat = self.config_file.stat()
+            new_mtime = file_stat.st_mtime_ns
+            new_ctime = file_stat.st_ctime_ns
+            new_inode = file_stat.st_ino
+            new_size = file_stat.st_size
+
+            # Check if modification time, inode, link count, or size has changed
+            if (
+                new_mtime != self._last_mtime
+                or new_ctime != self._last_ctime
+                or new_inode != self._last_inode
+                or new_size != self._last_file_size
+            ):
+                self._last_mtime = new_mtime
+                self._last_ctime = new_ctime
+                self._last_inode = new_inode
+                self._last_file_size = new_size
+                return True
+        except FileNotFoundError:
+            return True
+        return False
+
     def _read_config(self):
         try:
-            with open(self.config_file) as config_file:
+            with self.config_file.open("r") as config_file:
                 new_config = config_file.read()
 
             if new_config != self._previous_config:
@@ -75,13 +109,21 @@ class LogConfigWatcher(Thread):
 
                 return config_dict
         except FileNotFoundError:
+            if self.warn_only_once and self._warned:
+                return None
+
             self._missing_count += 1
             if self._missing_count % 4 == 0:
                 self.log.error("The logging configuration file %s is missing", self.config_file)
+                self._warned = True
+                self._missing_count = 0
         except JSONDecodeError:
             self.log.exception("The logging config has a syntax error")
         except Exception:
-            self.log.exception("Unexpected error while reading logging config file %s", self.config_file)
+            self.log.exception(
+                "Unexpected error while reading logging config file %s",
+                self.config_file,
+            )
 
         return None
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.1"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
 name = "attrs"
 version = "22.2.0"
 description = "Classes Without Boilerplate"
@@ -15,51 +37,12 @@ tests-no-zope = ["hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist", "c
 tests_no_zope = ["hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist", "cloudpickle", "mypy (>=0.971,<0.990)", "pytest-mypy-plugins"]
 
 [[package]]
-name = "autoflake"
-version = "2.0.0"
-description = "Removes unused imports and unused variables"
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-pyflakes = ">=3.0.0"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-
-[[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
-name = "click"
-version = "8.1.3"
-description = "Composable command line interface toolkit"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "colorama"
@@ -70,8 +53,19 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
 [[package]]
+name = "coverage"
+version = "5.5"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "exceptiongroup"
-version = "1.1.0"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -82,20 +76,43 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "6.0.0"
+version = "2.1.3"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "importlib-metadata"
+version = "4.8.3"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "sphinx-lint", "jaraco.tidelift (>=1.4)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "pytest-flake8", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "iniconfig"
@@ -106,57 +123,67 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "isort"
-version = "5.11.4"
-description = "A Python utility / library to sort Python imports."
+name = "more-itertools"
+version = "8.14.0"
+description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
-python-versions = ">=3.7.0"
-
-[package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
-plugins = ["setuptools"]
+python-versions = ">=3.5"
 
 [[package]]
-name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "packaging"
+version = "24.1"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
+name = "pathlib2"
+version = "2.3.7.post1"
+description = "Object-oriented filesystem paths"
 category = "dev"
 optional = false
 python-versions = "*"
 
-[[package]]
-name = "packaging"
-version = "23.0"
-description = "Core utilities for Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
+[package.dependencies]
+six = "*"
 
 [[package]]
-name = "pathspec"
-version = "0.10.3"
-description = "Utility library for gitignore style pattern matching of file paths."
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
-
-[[package]]
-name = "platformdirs"
-version = "2.6.2"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.5)", "sphinx (>=5.3)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "pluggy"
@@ -174,33 +201,148 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pyflakes"
-version = "3.0.1"
-description = "passive checker of Python programs"
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.7"
+description = "Python parsing module"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
 [[package]]
 name = "pytest"
-version = "7.2.0"
+version = "5.4.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.5"
 
 [package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=17.4.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+more-itertools = ">=4.0.0"
+packaging = "*"
+pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+wcwidth = "*"
+
+[package.extras]
+checkqa-mypy = ["mypy (==v0.761)"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest"
+version = "7.0.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+py = ">=1.8.2"
+tomli = ">=1.0.0"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest"
+version = "8.3.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "2.12.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+coverage = ">=5.2.1"
+pytest = ">=4.6"
+toml = "*"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "tomli"
+version = "1.2.3"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "tomli"
@@ -211,68 +353,69 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "typed-ast"
-version = "1.5.4"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
+name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "typing-extensions"
-version = "4.4.0"
-description = "Backported and Experimental Type Hints for Python 3.7+"
+name = "wcwidth"
+version = "0.2.13"
+description = "Measures the displayed width of unicode strings in a terminal"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = "*"
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "1.2.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7"
 
 [package.extras]
-docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "jaraco.functools", "more-itertools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "pytest-flake8"]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+
+[[package]]
+name = "zipp"
+version = "3.6.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "35a34fe7cf6aa59c65b6a42a6f85b507d6b2e45a07fe162e7904422f4ffc016b"
+python-versions = "^3.5"
+content-hash = "ae6e466f707ef3de2e138f4ee7f3167fac6df747793aae607441d651c81a096a"
 
 [metadata.files]
+atomicwrites = []
 attrs = []
-autoflake = []
-black = []
-click = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
-]
 colorama = []
+coverage = []
 exceptiongroup = []
 importlib-metadata = []
 iniconfig = []
-isort = []
-mypy-extensions = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
-]
+more-itertools = []
 packaging = []
-pathspec = []
-platformdirs = []
-pluggy = [
-    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
-    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
-]
-pyflakes = []
+pathlib2 = []
+pluggy = []
+py = []
+pyparsing = []
 pytest = []
-tomli = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-typed-ast = []
+pytest-cov = []
+six = []
+toml = []
+tomli = []
 typing-extensions = []
+wcwidth = []
 zipp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,20 +5,66 @@ description = "Watches your logging configuration file for change and applies th
 homepage = "https://github.com/RobertDeRose/log_config_watcher"
 documentation = "https://github.com/RobertDeRose/log_config_watcher/blob/main/README.md"
 readme = "README.md"
-authors = ["Robert DeRose <rderose@checkpt.com>"]
+authors = ["Robert DeRose <RobertDeRose@gmail.com>"]
 license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.5"
 
 [tool.poetry.dev-dependencies]
-black = "^22.12.0"
-autoflake = "^2.0.0"
-isort = "^5.11.4"
-pytest = "^7.2.0"
+pytest = [
+  {version="^5.0.0", python="<3.6"},
+  {version="^7.0.0", python=">=3.6,<3.8"},
+  {version="^8.0.0", python=">=3.8"}
+]
+pytest-cov = "*"
 
 [tool.poetry_bumpversion.file."log_config_watcher/__init__.py"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+fix = true
+line-length = 120
+output-format = "grouped"
+indent-width = 4
+target-version = "py310"
+
+[tool.ruff.lint]
+extend-fixable = [
+  "I", "F", "E", "N", "D", "UP"
+]
+
+[tool.ruff.format]
+docstring-code-format = true
+indent-style = "space"
+line-ending = "lf"
+quote-style = "double"
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+combine-as-imports = true
+force-sort-within-sections = true
+known-first-party = ["gpio"]
+known-third-party = []
+lines-after-imports = 2
+order-by-type = false
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder"
+]
+
+[tool.pytest.ini_options]
+addopts = "--disable-warnings -v --cov=log_config_watcher --cov-report=xml:coverage.xml"
+testpaths = ["tests"]
+
+[tool.markdownlint]
+MD013.line_length = 120
+
+[tool.codespell]
+skip = "*.po,*.ts,./tests,*.php"

--- a/tests/test_log_confg_watcher.py
+++ b/tests/test_log_confg_watcher.py
@@ -1,10 +1,243 @@
-import configparser
+import atexit
+from itertools import count
+import json
+import logging
+from pathlib import Path
+import time
+from unittest.mock import MagicMock, patch
 
-from log_config_watcher import __version__
+import pytest
+
+from log_config_watcher import LogConfigWatcher
 
 
-def test_version():
-    parser = configparser.ConfigParser()
-    parser.read("pyproject.toml")
-    version = parser["tool.poetry"]["version"].strip('"')
-    assert __version__ == version
+COUNTER = count(1).__next__
+CONFIG = {
+    "version": 1,
+    "formatters": {"default": {"format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"}},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "default",
+            "level": "INFO",
+        }
+    },
+    "root": {"level": "WARN", "handlers": ["console"]},
+}
+
+
+def write_text(text, file):
+    with open(file, "w") as f:
+        f.write(text)
+        f.flush()
+
+
+@pytest.fixture
+def mock_config_file():
+    config_file = Path("test_config_{}.json".format(COUNTER()))
+    write_text(json.dumps(CONFIG), config_file)
+    atexit.register(lambda: config_file.unlink())
+    return config_file
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock(spec=logging.Logger)
+
+
+def test_init(mock_config_file, mock_logger):
+    with patch("logging.getLogger", return_value=mock_logger):
+        watcher = LogConfigWatcher(mock_config_file)
+        assert watcher.config_file == mock_config_file
+        assert watcher.interval == 30
+        assert watcher._running is True
+        assert watcher._missing_count == -1
+        assert watcher.warn_only_once is False
+
+
+@patch("logging.getLogger")
+@patch("time.sleep")
+@patch.object(LogConfigWatcher, "_check_modification_time")
+def test_run_and_stop(mock_check_modification_time, mock_sleep, mock_get_logger, mock_config_file):
+    mock_logger = MagicMock(spec=logging.Logger)
+    mock_get_logger.return_value = mock_logger
+    mock_check_modification_time.return_value = False
+
+    watcher = LogConfigWatcher(mock_config_file, interval=1)
+    watcher.start()
+    time.sleep(0.1)  # Give the thread time to start
+
+    assert watcher.is_alive()
+    watcher.stop()
+    watcher.join(timeout=2)
+    assert not watcher.is_alive()
+
+    mock_sleep.assert_called()
+
+
+@patch("logging.getLogger")
+@patch("logging.config.dictConfig")
+@patch.object(LogConfigWatcher, "_check_modification_time")
+def test_update_on_file_change(mock_check_modification_time, mock_dict_config, mock_get_logger, mock_config_file):
+    mock_get_logger.return_value = MagicMock(spec=logging.Logger)
+    mock_check_modification_time.return_value = True
+
+    watcher = LogConfigWatcher(mock_config_file)
+    watcher._update()
+
+    mock_dict_config.assert_called_once()
+    mock_get_logger.return_value.info.assert_called_with("Applied new logging configuration")
+
+
+def test_file_not_found(mock_logger):
+    non_existent_file = Path("/non/existent/file.json")
+    with patch("logging.getLogger", return_value=mock_logger):
+        watcher = LogConfigWatcher(non_existent_file)
+        assert watcher._missing_count == 0  # Initial detection
+
+        watcher._update()
+        assert watcher._missing_count == 1  # After first update
+        mock_logger.error.assert_called_once_with("The logging configuration file %s is missing", non_existent_file)
+        mock_logger.error.reset_mock()
+
+        for i in range(2, 4):
+            watcher._update()
+            assert watcher._missing_count == i
+            mock_logger.error.assert_not_called()
+
+        watcher._update()
+        assert watcher._missing_count == 0  # resets after firing
+        mock_logger.error.assert_called_once_with("The logging configuration file %s is missing", non_existent_file)
+
+
+def test_file_not_found_warn_only_once(mock_logger):
+    non_existent_file = Path("/non/existent/file.json")
+    with patch("logging.getLogger", return_value=mock_logger):
+        watcher = LogConfigWatcher(non_existent_file, warn_only_once=True)
+        assert watcher._missing_count == 0  # Initial detection
+        mock_logger.error.assert_called_once_with("The logging configuration file %s is missing", non_existent_file)
+
+        mock_logger.error.reset_mock()
+        for _ in range(10):  # Multiple updates
+            watcher._update()
+            assert watcher._missing_count == 0
+            mock_logger.error.assert_not_called()  # No more error logs
+
+
+def test_invalid_json(mock_config_file, mock_logger):
+    write_text("invalid json", mock_config_file)
+    with patch("logging.getLogger", return_value=mock_logger):
+        watcher = LogConfigWatcher(mock_config_file)
+        watcher._update()
+
+        mock_logger.exception.assert_called_with("The logging config has a syntax error")
+
+
+@patch("logging.getLogger")
+@patch.object(Path, "open")
+def test_unexpected_error(mock_open, mock_get_logger, mock_config_file):
+    mock_logger = MagicMock(spec=logging.Logger)
+    mock_get_logger.return_value = mock_logger
+    mock_open.side_effect = Exception("Unexpected error")
+
+    watcher = LogConfigWatcher(mock_config_file)
+    watcher._update()
+
+    mock_logger.exception.assert_called_with("Unexpected error while reading logging config file %s", mock_config_file)
+
+
+@patch("logging.getLogger")
+@patch("logging.config.dictConfig")
+def test_config_unchanged(mock_dict_config, mock_get_logger, mock_config_file):
+    mock_logger = MagicMock(spec=logging.Logger)
+    mock_get_logger.return_value = mock_logger
+
+    watcher = LogConfigWatcher(mock_config_file)
+    watcher._update()  # First update
+    mock_dict_config.reset_mock()
+
+    watcher._update()  # Second update with no changes
+    mock_dict_config.assert_not_called()
+
+
+def test_check_modification_time(mock_config_file):
+    watcher = LogConfigWatcher(mock_config_file)
+
+    # First check should return True (initial read)
+    assert watcher._check_modification_time() is True
+
+    # Subsequent check without file modification should return False
+    assert watcher._check_modification_time() is False
+
+    # Modify file content
+    new_config = CONFIG.copy()
+    new_config["root"]["level"] = "WARN"
+    mock_config_file.unlink()
+    write_text(json.dumps(new_config), mock_config_file)
+
+    # Ensure enough time has passed for all systems to detect the change
+    time.sleep(0.2)  # 100 ms should be more than enough for most systems
+
+    # Check should detect the modification
+    assert watcher._check_modification_time() is True
+
+    # Subsequent check should return False again
+    assert watcher._check_modification_time() is False
+
+    # Test file deletion scenario
+    with patch.object(Path, "stat", side_effect=FileNotFoundError):
+        assert watcher._check_modification_time() is True
+
+
+@pytest.mark.parametrize(
+    "interval,default_format,default_level,default_handler,warn_only_once",
+    [
+        (60, "%(message)s", logging.INFO, logging.FileHandler("test.log"), False),
+        (
+            10,
+            "%(levelname)s: %(message)s",
+            logging.WARNING,
+            logging.NullHandler(),
+            True,
+        ),
+    ],
+)
+def test_custom_init_parameters(
+    mock_config_file,
+    interval,
+    default_format,
+    default_level,
+    default_handler,
+    warn_only_once,
+):
+    with patch("logging.basicConfig") as mock_basic_config:
+        watcher = LogConfigWatcher(
+            mock_config_file,
+            interval=interval,
+            default_format=default_format,
+            default_level=default_level,
+            default_handler=default_handler,
+            warn_only_once=warn_only_once,
+        )
+
+        assert watcher.interval == interval
+        assert watcher.warn_only_once == warn_only_once
+        mock_basic_config.assert_called_once_with(
+            level=default_level, format=default_format, handlers=[default_handler]
+        )
+
+
+def test_file_found_after_missing(mock_config_file, mock_logger):
+    with patch("logging.getLogger", return_value=mock_logger):
+        watcher = LogConfigWatcher(mock_config_file)
+        assert watcher._missing_count == -1  # Initial value
+
+        # Simulate file missing
+        with patch.object(Path, "open", side_effect=FileNotFoundError):
+            watcher._update()
+            assert watcher._missing_count == 0
+
+        # Simulate file found again
+        watcher._update()
+        assert watcher._missing_count == 0  # Stays at 0 after reset
+        mock_logger.info.assert_called_with("Logging configuration change detected")


### PR DESCRIPTION
This change is to help reduce the number of full file reads done while an application is run. The previous method would read in the entire configuration file and compare it for differences. This was inefficient and taxing on the some hardware like embedded devices.

In addition, there is a new flag to `warn_only_once` when the logging configuration file is missing. While it doesn't make a lot of sense to use this package without a logging configuration file, there might be type you run, like during testing and development you just wish to use the default logging it provides and not be spammed about a missing configuration file.

Whatever the case, the flag is there to be used if needed or wanted.