### PR TITLE
Feature: Allow setting custom logger name

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        pipx install poetry==1.1.5
+        pipx install poetry
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/log_config_watcher/log_config_watcher.py
+++ b/log_config_watcher/log_config_watcher.py
@@ -18,6 +18,7 @@ class LogConfigWatcher(Thread):
         default_level=logging.DEBUG,
         default_handler=logging.StreamHandler(),
         warn_only_once=False,
+        logger_name=None,
     ):
         """A Runnable thread that will monitor your logging configuration file for changes and apply them.
 
@@ -39,7 +40,7 @@ class LogConfigWatcher(Thread):
         """
         super().__init__(name="LogWatcher-{}".format(self.__COUNTER()), daemon=True)
 
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger(logger_name or __name__)
         self.config_file = Path(config_file)
         self.interval = interval
         self.warn_only_once = warn_only_once

--- a/tests/test_log_confg_watcher.py
+++ b/tests/test_log_confg_watcher.py
@@ -190,16 +190,11 @@ def test_check_modification_time(mock_config_file):
 
 
 @pytest.mark.parametrize(
-    "interval,default_format,default_level,default_handler,warn_only_once",
+    "interval,default_format,default_level,default_handler,warn_only_once,logger_name",
     [
-        (60, "%(message)s", logging.INFO, logging.FileHandler("test.log"), False),
-        (
-            10,
-            "%(levelname)s: %(message)s",
-            logging.WARNING,
-            logging.NullHandler(),
-            True,
-        ),
+        (60, "%(message)s", logging.INFO, logging.FileHandler("test.log"), False, None),
+        (10, "%(levelname)s: %(message)s", logging.WARNING, logging.NullHandler(), True, None),
+        (60, "%(message)s", logging.INFO, logging.FileHandler("test.log"), False, "test_watcher"),
     ],
 )
 def test_custom_init_parameters(
@@ -209,6 +204,7 @@ def test_custom_init_parameters(
     default_level,
     default_handler,
     warn_only_once,
+    logger_name,
 ):
     with patch("logging.basicConfig") as mock_basic_config:
         watcher = LogConfigWatcher(
@@ -218,10 +214,15 @@ def test_custom_init_parameters(
             default_level=default_level,
             default_handler=default_handler,
             warn_only_once=warn_only_once,
+            logger_name=logger_name,
         )
 
         assert watcher.interval == interval
         assert watcher.warn_only_once == warn_only_once
+        if logger_name is None:
+            assert watcher.log.name == "log_config_watcher.log_config_watcher"
+        else:
+            assert watcher.log.name == logger_name
         mock_basic_config.assert_called_once_with(
             level=default_level, format=default_format, handlers=[default_handler]
         )


### PR DESCRIPTION
The default is `__name__` but some users might want to set and control this.